### PR TITLE
fix: 修复SessionManager属性变化无法监听的问题

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -479,7 +479,7 @@ void SessionManager::SetLocked(bool lock)
     }
 
     m_locked = lock;
-    Q_EMIT lockedChanged(m_locked);
+    emitLockChanged(m_locked);
 }
 
 Q_DECL_DEPRECATED void SessionManager::Shutdown()
@@ -825,6 +825,36 @@ void SessionManager::reboot(bool force)
     qApp->quit();
 }
 
+void SessionManager::emitLockChanged(bool locked)
+{
+   QDBusMessage msg = QDBusMessage::createSignal("/org/deepin/dde/SessionManager1", "org.freedesktop.DBus.Properties", "PropertiesChanged");
+   QList<QVariant> arguments;
+   arguments.push_back("org.deepin.dde.SessionManager1");
+   QVariantMap changedProps;
+   changedProps.insert("Locked", locked);
+   arguments.push_back(changedProps);
+   msg.setArguments(arguments);
+   QDBusConnection::connectToBus(QDBusConnection::SessionBus, "org.deepin.dde.SessionManager1").send(msg);
+}
+
+void SessionManager::emitStageChanged(int state)
+{
+    Q_UNUSED(state);
+    // TODO 可能这个属性已经没用了，确认一下就可以删了
+}
+
+void SessionManager::emitCurrentSessionPathChanged(QDBusObjectPath path)
+{
+    Q_UNUSED(path);
+    // 这个属性不会变化
+}
+
+void SessionManager::emitCurrentUidChanged(QString uid)
+{
+    Q_UNUSED(uid);
+     // 这个属性不会变化
+}
+
 void SessionManager::handleLoginSessionLocked()
 {
     qDebug() << "login session locked.";
@@ -873,6 +903,6 @@ void SessionManager::handleLoginSessionUnlocked()
         } while (false);
 
         m_locked = false;
-        Q_EMIT lockedChanged(false);
+        emitLockChanged(false);
     }
 }

--- a/src/dde-session/impl/sessionmanager.h
+++ b/src/dde-session/impl/sessionmanager.h
@@ -19,10 +19,10 @@ class Inhibitor;
 class SessionManager : public QObject, public QDBusContext
 {
     Q_OBJECT
-    Q_PROPERTY(bool Locked READ locked NOTIFY lockedChanged)
-    Q_PROPERTY(int Stage READ stage NOTIFY stageChanged)
-    Q_PROPERTY(QDBusObjectPath CurrentSessionPath READ currentSessionPath NOTIFY currentSessionPathChanged)
-    Q_PROPERTY(QString CurrentUid READ currentUid NOTIFY currentUidChanged)
+    Q_PROPERTY(bool Locked READ locked /*NOTIFY lockedChanged*/)
+    Q_PROPERTY(int Stage READ stage /*NOTIFY stageChanged*/)
+    Q_PROPERTY(QDBusObjectPath CurrentSessionPath READ currentSessionPath /*NOTIFY currentSessionPathChanged*/)
+    Q_PROPERTY(QString CurrentUid READ currentUid /*NOTIFY currentUidChanged*/)
 
 public:
     static SessionManager *instance();
@@ -101,6 +101,12 @@ private:
     void shutdown(bool force);
     void reboot(bool force);
 
+    // 主动触发DBus的PropertiesChanged信息，否则调用方无法监听属性变化
+    void emitLockChanged(bool);
+    void emitStageChanged(int);
+    void emitCurrentSessionPathChanged(QDBusObjectPath);
+    void emitCurrentUidChanged(QString);
+
 private Q_SLOTS:
     void handleLoginSessionLocked();
     void handleLoginSessionUnlocked();
@@ -110,11 +116,6 @@ signals:
     void Unlock();
     void InhibitorAdded(const QDBusObjectPath &);
     void InhibitorRemoved(const QDBusObjectPath &);
-
-    void lockedChanged(bool);
-    void currentUidChanged(QString);
-    void stageChanged(int);
-    void currentSessionPathChanged(QDBusObjectPath);
 
 private:
     bool m_locked;


### PR DESCRIPTION
属性变化时,需要服务提供方主动通知DBus,之前都是没通知的

Log: 修复SessionManager属性变化无法监听的问题
Influence: 暂无
Task: https://pms.uniontech.com/task-view-230459.html
Change-Id: Iae643a54536418e8f3999b0d93271fc646fcbfb0