### PR TITLE
fix: 切换用户后打开关机界面异常

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -861,8 +861,9 @@ void SessionManager::emitCurrentUidChanged(QString uid)
 
 void SessionManager::handleLoginSessionLocked()
 {
-    qDebug() << "login session locked.";
-    // 在特殊情况下，比如用 dde-switchtogreeter 命令切换到 greeter, 即切换到其他 tty, RequestLock 方法不能立即返回。
+    qDebug() << "login session locked." << locked();
+    // 在特殊情况下，比如用 dde-switchtogreeter 命令切换到 greeter, 即切换到其他 tty
+    // 前端(登录界面和锁屏界面)已绑定锁定信号进行了处理，此处只需更新Locked属性。
 
     // 如果已经锁定，则立即返回
     if (locked()) {
@@ -870,7 +871,8 @@ void SessionManager::handleLoginSessionLocked()
         return;
     }
 
-    RequestLock();
+    m_locked = true;
+    emitLockChanged(true);
 }
 
 void SessionManager::handleLoginSessionUnlocked()


### PR DESCRIPTION
通过dde-switchtogreeter切换用户后，调用RequestLock会导致dde-session主线程阻塞 切换用户时，dde-lock已经绑定锁定信号进行了相关处理，dde-session只需要更新锁定信号即可

Log: 修复切换用户后打开关机界面异常的问题
Bug: https://github.com/linuxdeepin/developer-center/issues/3584
Influence: 登录/锁屏账户切换