### PR TITLE
chore!: use DDE for current desktop name

### DIFF
--- a/src/dde-session/environmentsmanager.cpp
+++ b/src/dde-session/environmentsmanager.cpp
@@ -75,7 +75,7 @@ void EnvironmentsManager::createGenernalEnvironments()
     double scaleFactor = Utils::SettingValue("com.deepin.xsettings", QByteArray(), "scale-factor", 1.0).toDouble();
     m_envMap = {
         {"GNOME_DESKTOP_SESSION_ID", "this-is-deprecated"},
-        {"XDG_CURRENT_DESKTOP", "Deepin"},
+        {"XDG_CURRENT_DESKTOP", "DDE"},
         {"QT_DBL_CLICK_DIST", QString::number(15 * scaleFactor)},
         {"QT_LINUX_ACCESSIBILITY_ALWAYS_ON", "1"},
     };


### PR DESCRIPTION
使用 DDE 作为当前桌面环境的名称。

注意，检查并使用 XDG_CURRENT_DESKTOP 环境变量的 DDE 组件与应用应当能正常处理 DDE 作为桌面环境名称的情况。

相关：

- https://github.com/linuxdeepin/developer-center/issues/3829