### PR TITLE
fix: dde-display doesn't start logout steps when stopped

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-display.service
+++ b/systemd/dde-session-initialized.target.wants/dde-display.service
@@ -22,6 +22,5 @@ After=dde-session-initialized.target
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/startdde
-ExecStopPost=/usr/lib/libexec/dde-session-ctl --shutdown
 TimeoutStartSec=infinity
 Slice=services.slice


### PR DESCRIPTION
Closed: https://github.com/linuxdeepin/developer-center/issues/3933
