### PR TITLE
fix: wine window shadows not following

### DIFF
--- a/misc/wayland-sessions/dde-wayland.desktop.in
+++ b/misc/wayland-sessions/dde-wayland.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=DDE (Wayland)
+Name=deepin
 Comment=Deepin Desktop Environment
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/dde-session
 TryExec=@CMAKE_INSTALL_FULL_BINDIR@/dde-session

--- a/misc/xsessions/dde-x11.desktop.in
+++ b/misc/xsessions/dde-x11.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=DDE (X11)
+Name=deepin
 Comment=Deepin Desktop Environment
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/dde-session
 TryExec=@CMAKE_INSTALL_FULL_BINDIR@/dde-session


### PR DESCRIPTION
Temporarily restore the name of the desktop environment as deepin, and adjust it to DDE when the official version is released
