### PR TITLE
fix: not in the correct exit order

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -168,12 +168,8 @@ void SessionManager::prepareLogout(bool force)
 void SessionManager::doLogout()
 {
 #ifndef QT_DEBUG
-    QDBusPendingReply<> reply = m_login1SessionInter->Terminate();
-    if (reply.isError()) {
-        qWarning() << "failed to terminate session self";
-    }
-
-    qApp->quit();
+    QDBusInterface systemd("org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager");
+    qInfo() << systemd.call("StartUnit", "dde-session-shutdown.target", "replace-irreversibly");
 #else
     qInfo() << "logout completed, bug not now";
 #endif

--- a/src/dde-session/main.cpp
+++ b/src/dde-session/main.cpp
@@ -93,8 +93,9 @@ int main(int argc, char *argv[])
         startSystemdUnit(systemdDBus, dmService, "replace");
 
         QDBusServiceWatcher *watcher = new QDBusServiceWatcher("org.deepin.dde.Session1", QDBusConnection::sessionBus(), QDBusServiceWatcher::WatchForUnregistration);
-        watcher->connect(watcher, &QDBusServiceWatcher::serviceUnregistered, [=] {
+        watcher->connect(watcher, &QDBusServiceWatcher::serviceUnregistered, [&] {
             qInfo() << "dde session exit";
+            startSystemdUnit(systemdDBus, "dde-session-exit-task.service", "replace");
             qApp->quit();
         });
         pid_t curPid = getpid();

--- a/systemd/dde-session-shutdown.target
+++ b/systemd/dde-session-shutdown.target
@@ -27,6 +27,3 @@ After=services.slice components.slice
 # Note that this can also be improved by reversing the conflicts above and
 # not listing them in the shutdown unit.
 StopWhenUnneeded=true
-
-Wants=dde-session-exit-task.service
-Before=dde-session-exit-task.service


### PR DESCRIPTION
It is necessary to ensure that the session is the last to exit, otherwise Xorg exit will cause all processes to crash.