### PR TITLE
fix: disable use GLX_EXT_buffer_age in kwin

### DIFF
--- a/systemd/dde-session@x11.service
+++ b/systemd/dde-session@x11.service
@@ -32,6 +32,7 @@ ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "%I" || exit 2'
 ExecStart=/usr/bin/deepin-kwin_x11 --replace
 # Exit code 1 means we are probably *not* dealing with an extension failure
 SuccessExitStatus=1
+Environment=KWIN_USE_BUFFER_AGE=0
 
 # On X11 we do not need to unset any variables
 


### PR DESCRIPTION
The GLX_EXT_buffer_age allow extension is to expose enough information to applications about how the driver manages the set of front and back buffers associated with a given surface to allow applications to re-use the contents of old frames and minimize how much must be redrawn for the next frame.

If using GLX_EXT_buffer_age on kwin, it's using the repaint area from the damage areas to do partial refresh in compositor. On some platform(Intel, Maybe a driver bug), when dpms off and dpms on soon(The interval of one second may be repeated), you will see the screen is flash with the some part of black in some frame, maybe one buffer of front buffer and back buffer is broke, and kwin only draw a part of the buffer, so the other part of the buffer is black.

Though not verify this bug is from GLX_EXT_buffer_age, but the kwin say "It may cause artifacts, so you can try to disable it" in document and this bug is clear when I disable it. So add environment variant "KWIN_USE_BUFFER_AGE=0" to disable use the extension in kwin to avoid this bug.

TODO: If you verify the bug isn't from GLX_EXT_buffer_age, you can fix it and enable KWIN_USE_BUFFER_AGE.

Issue: https://github.com/linuxdeepin/developer-center/issues/4252