### PR TITLE
chore: remove Qt font set through xsettings

### DIFF
--- a/tools/dde-xsettings-checker/xsettingschecker.cpp
+++ b/tools/dde-xsettings-checker/xsettingschecker.cpp
@@ -33,53 +33,10 @@ void XSettingsChecker::init()
 {
     qDebug() << "xsettings checker";
 
-    initXSettingsFont();
     initQtTheme();
     initLeftPtrCursor();
 
     qDebug() << "xsettings checker finished";
-}
-
-void XSettingsChecker::initXSettingsFont()
-{
-    QString defaultFont;
-    QString defaultMonoFont;
-    loadDefaultFontConfig(defaultFont, defaultMonoFont);
-
-    // check xs font name
-    {
-        QDBusPendingReply<QString> reply = GetXSettingsString("Qt/FontName");
-        if (reply.isError()) {
-            qWarning() << "failed to get font name from xsettings service, error: " << reply.error().name();
-        } else {
-            const QString &xSettingsFontName = reply.value();
-            if (xSettingsFontName.isEmpty()) {
-                reply = SetXSettingsString("Qt/FontName", defaultFont);
-                if (reply.isError()) {
-                    qWarning() << "failed to set font name to xsettings service, error: " << reply.error().name();
-                }
-                qDebug() << "set qt font to xsettings service: " << defaultFont;
-            }
-        }
-    }
-
-    // check xs mono font name
-    {
-        QDBusPendingReply<QString> reply = GetXSettingsString("Qt/MonoFontName");
-        if (reply.isError()) {
-            qWarning() << "failed to get mono font name from xsettings service, error: " << reply.error().name();
-        } else {
-            const QString &xSettingsMonoFontName = reply.value();
-            if (xSettingsMonoFontName.isEmpty()) {
-                reply = SetXSettingsString("Qt/MonoFontName", defaultMonoFont);
-                if (reply.isError()) {
-                    qWarning() << "failed to set mono font name to xsettings service, error: " << reply.error().name();
-                } else {
-                    qDebug() << "set qt mono font to xsettings service: " << defaultMonoFont;
-                }
-            }
-        }
-    }
 }
 
 void XSettingsChecker::initQtTheme()
@@ -106,24 +63,6 @@ void XSettingsChecker::initQtTheme()
         settings.setValue("FontSize", fontSize);
         qDebug() << "set font size in qt theme: " << fontSize;
     }
-
-    // font
-    QString fontName = settings.value("Font").toString();
-    if (fontName.isEmpty()) {
-        QString unused;
-        loadDefaultFontConfig(fontName, unused);
-        settings.setValue("Font", fontName);
-        qDebug() << "set font name in qt theme: " << fontName;
-    }
-
-    // mono font
-    QString monoFontName = settings.value("MonFont").toString();
-    if (monoFontName.isEmpty()) {
-        QString unused;
-        loadDefaultFontConfig(unused, monoFontName);
-        settings.setValue("MonFont", monoFontName);
-        qDebug() << "set mono font name in qt theme: " << monoFontName;
-    }
 }
 
 /**
@@ -133,42 +72,6 @@ void XSettingsChecker::initQtTheme()
 void XSettingsChecker::initLeftPtrCursor()
 {
     xc_left_ptr_to_watch(0);
-}
-
-void XSettingsChecker::loadDefaultFontConfig(QString &defaultFont, QString &defaultMonoFont)
-{
-    // 从配置文件中获取信息
-    QFile fontFile("/usr/share/deepin-default-settings/fontconfig.json");
-    if (!fontFile.exists() || !fontFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "font config not exists, maybe we found an error in `deepin-default-settings`";
-        defaultFont = "Noto Sans";
-        defaultMonoFont = "Noto Mono";
-        return;
-    }
-
-    // 解析配置文件
-    QJsonParseError jsonError;
-    QJsonDocument jsonDocument = QJsonDocument::fromJson(fontFile.readAll(), &jsonError);
-    if (jsonError.error != QJsonParseError::NoError) {
-        qWarning() << "failed to parse font config, error type: " << jsonError.error;
-        defaultFont = "Noto Sans";
-        defaultMonoFont = "Noto Mono";
-        return;
-    }
-
-    // 获取当前用户语言的默认字体信息
-    QJsonObject rootObj = jsonDocument.object();
-    QJsonValue rootValue = rootObj.value(QLocale().name());
-    QJsonObject localeObj = rootValue.toObject();
-    defaultFont = localeObj.value("Standard").toString();
-    defaultMonoFont = localeObj.value("Mono").toString();
-    if (defaultFont.isEmpty())
-        defaultFont = "Noto Sans";
-    if (defaultMonoFont.isEmpty())
-        defaultMonoFont = "Noto Mono";
-
-    qDebug() << "default font: " << defaultFont
-             << ", default mono font: " << defaultMonoFont;
 }
 
 QDBusPendingReply<QString> XSettingsChecker::GetXSettingsString(const QString &prop)

--- a/tools/dde-xsettings-checker/xsettingschecker.h
+++ b/tools/dde-xsettings-checker/xsettingschecker.h
@@ -21,11 +21,8 @@ public:
     void init();
 
 private:
-    void initXSettingsFont();
     void initQtTheme();
     void initLeftPtrCursor();
-
-    void loadDefaultFontConfig(QString &defaultFont, QString &defaultMonoFont);
 
     QDBusPendingReply<QString> GetXSettingsString(const QString &prop);
     QDBusPendingReply<> SetXSettingsString(const QString &prop, const QString &value);


### PR DESCRIPTION
Use fontconfig configuration to implement different fonts for different languages instead of regenerating
the fontconfig configuration after switching languages.