### PR TITLE
fix: dde-desktop启动应依赖dde-appearance服务

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(DtkTools REQUIRED)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set (CMAKE_CXX_STANDARD 11)
@@ -8,7 +10,7 @@ file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/dbusinterface/)
 set(QT_DBUS_INTERFACE_INCLUDE ${PROJECT_BINARY_DIR}/dbusinterface/)
 
 macro(qt5_add_dbus_interface_fix srcs xml class file)
-  execute_process(COMMAND qdbusxml2cpp-fix -c ${class} -p ${PROJECT_BINARY_DIR}/dbusinterface/${file} ${PROJECT_SOURCE_DIR}/dbus/interface/${xml})
+  execute_process(COMMAND ${DTK_XML2CPP} -c ${class} -p ${PROJECT_BINARY_DIR}/dbusinterface/${file} ${PROJECT_SOURCE_DIR}/dbus/interface/${xml})
   list(APPEND ${srcs}
     ${PROJECT_BINARY_DIR}/dbusinterface/${file}.h
     ${PROJECT_BINARY_DIR}/dbusinterface/${file}.cpp

--- a/systemd/dde-session-initialized.target.wants/dde-desktop.service
+++ b/systemd/dde-session-initialized.target.wants/dde-desktop.service
@@ -15,6 +15,8 @@ Before=dde-session-initialized.target
 Requires=dbus.socket
 After=dbus.socket
 
+Wants=dde-appearance.service
+
 [Service]
 Type=simple
 ExecStart=/usr/bin/dde-desktop


### PR DESCRIPTION
dde-desktop启动依赖dde-appearance服务

Log: 修复设置自定义壁纸后桌面壁纸黑屏的问题
Influence: 桌面壁纸正确显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4778