### PR TITLE
fix: stop pipewire in logout

### DIFF
--- a/src/dde-session/impl/sessionmanager.h
+++ b/src/dde-session/impl/sessionmanager.h
@@ -82,6 +82,7 @@ private:
     void clearCurrentTty();
 
     // tiny function
+    QString getAudioServerBackend();
     void stopSogouIme();
     void stopLangSelector();
     void launchAutostopScripts();

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -12,6 +12,8 @@
 #define AT_SPI_SERVICE "at-spi-dbus-bus.service"
 #define OBEX_SERVICE "obex.service"
 #define PULSEAUDIO_SERVICE "pulseaudio.service"
+#define PIPEWIRE_SOCKET "pipewire.socket"
+#define PIPEWIRE_PULSE_SOCKET "pipewire-pulse.socket"
 #define BAMFDAEMON_SERVICE "bamfdaemon.service"
 #define REDSHIFT_SERVICE "redshift.service"
 


### PR DESCRIPTION
pipewire should be stop in logout

Log: 修复注销后重新登录无法识别到声音设备的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/5193