### PR TITLE
fix: Disorder between dde-lock and dde-session-daemon

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-lock.service
+++ b/systemd/dde-session-initialized.target.wants/dde-lock.service
@@ -12,6 +12,9 @@ Requisite=dde-session-initialized.target
 PartOf=dde-session-initialized.target
 Before=dde-session-initialized.target
 
+Wants=org.dde.session.Daemon1.service
+After=org.dde.session.Daemon1.service
+
 [Service]
 Type=simple
 ExecStart=/usr/bin/dde-lock


### PR DESCRIPTION
  Lock's network is invalid in dde-lock, it need dde-session-daemon's
network dbus service.

Issue: https://github.com/linuxdeepin/developer-center/issues/4916