### PR TITLE
fix: qt warning about obsolete usage of QString::SkipEmptyParts

### DIFF
--- a/src/dde-session/impl/iowait/iowaitwatcher.cpp
+++ b/src/dde-session/impl/iowait/iowaitwatcher.cpp
@@ -74,7 +74,7 @@ void IOWaitWatcher::onTimeOut()
     }
 
     const QString &line = file.readLine();
-    const QStringList &list = line.split(" ", QString::SkipEmptyParts);
+    const QStringList &list = line.split(" ", Qt::SkipEmptyParts);
     if (list.size() < 6) {
         qWarning() << "invalid format: " << line;
         return;


### PR DESCRIPTION
Use Qt::SkipEmptyParts instead.

Fixes the following warning:
```
[33/68] Building CXX object
src/dde-session/CMakeFiles/dde-session.dir/impl/iowait/iowaitwatcher.cpp.o
/home/felix/projects/deepin/dde-session/src/dde-session/impl/iowait/iowaitwatcher.cpp:
In member function ‘void IOWaitWatcher::onTimeOut()’:
/home/felix/projects/deepin/dde-session/src/dde-session/impl/iowait/iowaitwatcher.cpp:77:41:
warning: ‘QStringList QString::split(const QString&, SplitBehavior,
Qt::CaseSensitivity) const’ is deprecated: Use split(const QString &sep,
Qt::SplitBehavior ...) variant instead [-Wdeprecated-declarations]
   77 |     const QStringList &list = line.split(" ",
      QString::SkipEmptyParts);
            |
            ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```