### PR TITLE
fix: update env for dbus session

### DIFF
--- a/src/dde-session/main.cpp
+++ b/src/dde-session/main.cpp
@@ -9,6 +9,7 @@
 #include <QElapsedTimer>
 #include <QTimer>
 #include <QDebug>
+#include <QProcess>
 #include <QtConcurrent>
 
 #include <DLog>
@@ -86,6 +87,10 @@ int main(int argc, char *argv[])
         DLogManager::registerFileAppender();
 
         EnvironmentsManager().init();
+
+        // sync environment variables. debian does this by default, but other distributions may not.
+        QProcess updater;
+        updater.execute("dbus-update-activation-environment --verbose --systemd --all");
 
         QString dmService = "dde-session.target";
         qInfo() << "start dm service:" << dmService;


### PR DESCRIPTION
Debian does this by default as a customized Xsession script, but DDE shouldn't rely on this behavior.

Debian script:
https://salsa.debian.org/utopia-team/dbus/-/blob/debian/unstable/debian/95dbus_update-activation-env

KDE has similar logic:
https://github.com/KDE/plasma-workspace/blob/master/libkworkspace/updatelaunchenvjob.cpp

Fixes DDE v23 on Arch.