### PR TITLE
fix: fix-linglong app is missing

### DIFF
--- a/src/dde-session/environmentsmanager.cpp
+++ b/src/dde-session/environmentsmanager.cpp
@@ -75,13 +75,10 @@ void EnvironmentsManager::init()
 void EnvironmentsManager::createGeneralEnvironments()
 {
     double scaleFactor = Utils::SettingValue("com.deepin.xsettings", QByteArray(), "scale-factor", 1.0).toDouble();
-    auto envs = QProcessEnvironment::systemEnvironment();
-    auto keys = envs.keys();
+    QByteArray sessionType = qgetenv("XDG_SESSION_TYPE");
 
-    for (const auto& key : keys) {
-        m_envMap.insert(key, envs.value(key));
-    }
-
+    // only insert partially needed env, do not set other environment
+    m_envMap.insert("XDG_SESSION_TYPE", sessionType);
     m_envMap.insert("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated");
     m_envMap.insert("XDG_CURRENT_DESKTOP", "DDE");
     m_envMap.insert("QT_DBL_CLICK_DIST", QString::number(15 * scaleFactor));


### PR DESCRIPTION
systemd env(XDG_DATA_DIRS) is replaced by dde-session env so dde-session only set partially needed

Log: