### PR TITLE
chore: update startdde version to 6.0.11

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Homepage: https://www.deepin.org
 Package: dde-session
 Architecture: any
 Depends:
- startdde (>= 6.0.4),
+ startdde (>= 6.0.11),
  ${misc:Depends},
  ${shlibs:Depends},
 Description: dde session module


### PR DESCRIPTION
bump dde-session depends startdde version to 6.0.11

Log: