### PR TITLE
fix: will cause kde to fail to start

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-osd.service
+++ b/systemd/dde-session-initialized.target.wants/dde-osd.service
@@ -18,6 +18,7 @@ Before=dde-session-initialized.target
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
+ExecCondition=/bin/sh -c 'test "$XDG_CURRENT_DESKTOP" = "DDE" || exit 2'
 ExecStart=/usr/lib/deepin-daemon/dde-osd
 TimeoutStartSec=infinity
 Slice=session.slice

--- a/systemd/dde-session@wayland.service
+++ b/systemd/dde-session@wayland.service
@@ -18,8 +18,7 @@ PartOf=graphical-session.target
 
 [Service]
 Slice=session.slice
-BusName=org.kde.KWinWrapper
-Type=dbus
+Type=simple
 # NOTE: This can be replaced with ConditionEnvironment=XDG_SESSION_TYPE=%I in
 #       the [Unit] section with systemd >= 246. Also, the current solution is
 #       kind of painful as systemd had a bug where it retries the condition.
@@ -36,3 +35,4 @@ ExecStopPost=-/bin/sh -c 'test "$SERVICE_RESULT" != "exec-condition" && systemct
 Restart=no
 # Kill any stubborn child processes after this long
 TimeoutStopSec=5
+TimeoutStartSec=infinity

--- a/systemd/dde-session@x11.service
+++ b/systemd/dde-session@x11.service
@@ -22,8 +22,7 @@ StartLimitBurst=1
 
 [Service]
 Slice=session.slice
-BusName=org.kde.KWin
-Type=dbus
+Type=simple
 # NOTE: This can be replaced with ConditionEnvironment=XDG_SESSION_TYPE=%I in
 #       the [Unit] section with systemd >= 246. Also, the current solution is
 #       kind of painful as systemd had a bug where it retries the condition.
@@ -41,3 +40,4 @@ Restart=always
 RestartSec=0ms
 # Kill any stubborn child processes after this long
 TimeoutStopSec=5
+TimeoutStartSec=infinity


### PR DESCRIPTION
kde will start kwin, which will cause dde-session@x11/wayland.service to start as a dbus service.

Log: