### PR TITLE
fix: logging out takes a long time

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -612,11 +612,12 @@ void SessionManager::stopObexService()
 
 void SessionManager::stopPulseAudioService()
 {
-    auto msg = QDBusInterface("org.deepin.dde.Audio1"
+    QDBusInterface interface("org.deepin.dde.Audio1"
                               , "/org/deepin/dde/Audio1"
                               , "org.deepin.dde.Audio1"
-                              , QDBusConnection::sessionBus(), this)
-            .call("NoRestartPulseAudio");
+                              , QDBusConnection::sessionBus(), this);
+    interface.setTimeout(1000);
+    auto msg = interface.call("NoRestartPulseAudio");
     if (!msg.errorMessage().isEmpty())
         qWarning() << "error: " << msg.errorMessage();
 


### PR DESCRIPTION
调用 org.deepin.dde.Audio1 接口设置 1s 超时

Issues: linuxdeepin/developer-center#7980