### PR TITLE
chore: bump version to 1.2.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.2.8) unstable; urgency=medium
+
+  * fix: logging out takes a long time
+
+ -- zsien <quezhiyong@deepin.org>  Wed, 24 Apr 2024 13:49:56 +0800
+
 dde-session (1.2.7) unstable; urgency=medium
 
   * chore: dde-shell replace dde-dock


### PR DESCRIPTION
  * fix: logging out takes a long time