### PR TITLE
chore: limit some dde service run to x11

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -31,6 +31,7 @@ install(DIRECTORY DESTINATION lib/systemd/user/dde-session-initialized.target.wa
 set(DDE_SESSION_INITIALIZED_WANTS
     dde-session-initialized.target.wants/dde-desktop.service
     dde-session-initialized.target.wants/dde-shell@DDE.service
+    dde-session-initialized.target.wants/dde-shell@TreeLand.service
     dde-session-initialized.target.wants/dde-lock.service
     dde-session-initialized.target.wants/dde-osd.service
     dde-session-initialized.target.wants/dde-osd.target
@@ -43,6 +44,7 @@ install_symlink(dde-session@x11.service dde-session-pre.target.wants)
 install_symlink(dde-display.service dde-session-pre.target.wants)
 install_symlink(dde-desktop.service dde-session-initialized.target.wants)
 install_symlink(dde-shell@DDE.service dde-session-initialized.target.wants)
+install_symlink(dde-shell@TreeLand.service dde-session-initialized.target.wants)
 install_symlink(dde-lock.service dde-session-initialized.target.wants)
 install_symlink(dde-polkit-agent.service dde-session-initialized.target.wants)
 install_symlink(dde-osd.service dde-session-initialized.target.wants)

--- a/systemd/dde-session-initialized.target.wants/dde-shell@TreeLand.service
+++ b/systemd/dde-session-initialized.target.wants/dde-shell@TreeLand.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=dde-shell for DDE service
+Description=dde-shell for DDE service on TreeLand
 RefuseManualStart=no
 RefuseManualStop=no
 StartLimitBurst=3
@@ -23,13 +23,10 @@ After=org.deepin.dde.Application1.Manager.service
 Wants=org.desktopspec.ApplicationManager1.service
 After=org.desktopspec.ApplicationManager1.service
 
-Wants=org.dde.session.Daemon1.service
-After=org.dde.session.Daemon1.service
-
 [Service]
 Type=simple
-ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "x11" || exit 2'
-ExecStart=/usr/bin/dde-shell -C %I
+ExecCondition=/bin/sh -c 'test "$DDE_CURRENT_COMPOSITOR" = "%I" || exit 2'
+ExecStart=/usr/bin/dde-shell -C DDE -d org.deepin.ds.dock.tray
 TimeoutStartSec=infinity
 Slice=session.slice
 Restart=on-failure

--- a/systemd/dde-session-pre.target.wants/dde-display.service
+++ b/systemd/dde-session-pre.target.wants/dde-display.service
@@ -1,11 +1,5 @@
 [Unit]
 Description=dde-display service
-RefuseManualStart=no
-RefuseManualStop=no
-StartLimitBurst=3
-OnFailure=dde-session-shutdown.target
-OnFailureJobMode=replace-irreversibly
-CollectMode=inactive-or-failed
 
 Requires=dbus.socket
 After=dbus.socket
@@ -19,7 +13,7 @@ Before=dde-session@x11.service
 [Service]
 Type=notify
 NotifyAccess=all
-ExecCondition=/bin/sh -c 'test "$DISPLAY" != "" || exit 2'
+ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "x11" || exit 2'
 ExecStart=/usr/bin/startdde
 TimeoutStartSec=infinity
 Slice=session.slice


### PR DESCRIPTION
disable startdde and dde-shell full plugins mode on TreeLand
    