### PR TITLE
chore: startdde can work under xwayland

### DIFF
--- a/systemd/dde-session-pre.target.wants/dde-display.service
+++ b/systemd/dde-session-pre.target.wants/dde-display.service
@@ -13,7 +13,7 @@ Before=dde-session@x11.service
 [Service]
 Type=notify
 NotifyAccess=all
-ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "x11" || exit 2'
+ExecCondition=/bin/sh -c 'test "$DISPLAY" != "" || exit 2'
 ExecStart=/usr/bin/startdde
 TimeoutStartSec=infinity
 Slice=session.slice


### PR DESCRIPTION
switch to check DISPLAY environment.

Log: