### PR TITLE
chore: remove 94qt_env

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -3,7 +3,6 @@ configure_file(xsessions/dde-x11.desktop.in xsessions/dde-x11.desktop)
 set(XSESSION
     ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/00deepin-dde-env
     ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/01deepin-profile
-    ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/94qt_env
 )
 
 set(PROFILE

--- a/misc/Xsession.d/94qt_env
+++ b/misc/Xsession.d/94qt_env
@@ -1,9 +1,0 @@
-case $XDG_SESSION_TYPE in
-    x11)
-        export QT_QPA_PLATFORM="dxcb;xcb"
-        ;;
-    wayland)
-        export QT_QPA_PLATFORM=wayland
-        export QT_WAYLAND_SHELL_INTEGRATION="xdg-shell;wl-shell;ivi-shell;qt-shell;"
-        ;;
-esac


### PR DESCRIPTION
由于此配置仅在 debian 下生效，现相关逻辑已移至 environmentsmanager，故不再需要此配置。

另见： https://github.com/linuxdeepin/dde-session/pull/86