### PR TITLE
fix: the language change in Treeland is not work

### DIFF
--- a/src/dde-session/environmentsmanager.cpp
+++ b/src/dde-session/environmentsmanager.cpp
@@ -120,6 +120,23 @@ void EnvironmentsManager::createDBusEnvironments()
     for (auto env : additionalEnvs) {
         m_envMap.insert(env, qgetenv(env));
     }
+
+    QByteArray sessionType = qgetenv("XDG_SESSION_TYPE");
+    if (sessionType == "wayland") {
+        QFile localeFile(QStandardPaths::locate(QStandardPaths::ConfigLocation, "locale.conf"));
+        if (localeFile.open(QIODevice::ReadOnly)) {
+            QTextStream in(&localeFile);
+
+            while (!in.atEnd()) {
+                QString line = in.readLine();
+                if (line.startsWith("LANG=")) {
+                    m_envMap.insert("LANG", line.mid(strlen("LANG=")));
+                } else if (line.startsWith("LANGUAGE=")) {
+                    m_envMap.insert("LANGUAGE", line.mid(strlen("LANGUAGE=")));
+                }
+            }
+        }
+    }
 }
 
 bool EnvironmentsManager::unsetEnv(QString env)


### PR DESCRIPTION
treeland 下不走 Xsession。手动读取 ~/.config/locale.conf

Log: 修复 treeland 下修改语言不生效
PMS: bug-294913