### PR TITLE
chore: rename deepin-kwin to kwin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.99.12) unstable; urgency=medium
+
+  * rename deepin-kwin to kwin
+
+ -- rewine <luhongxu@uniontech.com>  Mon, 24 Mar 2025 10:33:39 +0800
+
 dde-session (1.99.11) unstable; urgency=medium
 
   * fix: return value spelling error

--- a/src/dde-session/othersmanager.cpp
+++ b/src/dde-session/othersmanager.cpp
@@ -44,7 +44,7 @@ void OthersManager::launchWmChooser()
     }
 
     // kwin存在的情况
-    if (!QStandardPaths::findExecutable("deepin-kwin_x11").isEmpty() && QFile(config).exists()) {
+    if (!QStandardPaths::findExecutable("kwin_x11").isEmpty() && QFile(config).exists()) {
         QFile configFile(config);
         if (!configFile.open(QIODevice::ReadOnly)) {
             qWarning() << "failed to open file: " << config;
@@ -64,7 +64,7 @@ void OthersManager::launchWmChooser()
         bool compositingEnabled = (lastWm == "deepin-wm");
 
         // 更新kwinrc的配置文件
-        const QString &kwinRc = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin-kwinrc";
+        const QString &kwinRc = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/kwinrc";
         QSettings settings(kwinRc, QSettings::IniFormat);
         settings.beginGroup("Compositing");
         settings.setValue("Enabled", compositingEnabled);

--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -22,7 +22,7 @@ Type=notify
 # Only start if the template instance matches the session type.
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "%I" || exit 2'
 ExecStartPre=-/bin/sh -c 'cp -n /etc/xdg/kglobalshortcutsrc $HOME/.config/kglobalshortcutsrc'
-ExecStart=/usr/bin/deepin-kwin_x11 --replace
+ExecStart=/usr/bin/kwin_x11 --replace
 # Exit code 1 means we are probably *not* dealing with an extension failure
 SuccessExitStatus=1
 


### PR DESCRIPTION
Log: refork kwin form uos, don't rename

## Summary by Sourcery

Chores:
- Rename deepin-kwin to kwin.