### PR TITLE
chore: bump version to 1.99.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.99.13) unstable; urgency=medium
+
+  * chore: remove startdde dependency
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 03 Apr 2025 15:14:45 +0800
+
 dde-session (1.99.12) unstable; urgency=medium
 
   * rename deepin-kwin to kwin


### PR DESCRIPTION
chore: remove startdde dependency

## Summary by Sourcery

Chores:
- Update project version in changelog to 1.99.13