### PR TITLE
fix: auto rename deepin-kwin config in kglobalshortcutsrc

### DIFF
--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -22,6 +22,7 @@ Type=notify
 # Only start if the template instance matches the session type.
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "%I" || exit 2'
 ExecStartPre=-/bin/sh -c 'cp -n /etc/xdg/kglobalshortcutsrc $HOME/.config/kglobalshortcutsrc'
+ExecStartPre=-/bin/sh -c 'sed -i "s/deepin-kwin/kwin/g" $HOME/.config/kglobalshortcutsrc'
 ExecStart=/usr/bin/kwin_x11 --replace
 # Exit code 1 means we are probably *not* dealing with an extension failure
 SuccessExitStatus=1


### PR DESCRIPTION
log: in deepin-kwin 6.0.0, will read kwin group, not dde-kwin

## Summary by Sourcery

Bug Fixes:
- Correct the configuration group name for deepin-kwin in kglobalshortcutsrc to ensure proper configuration reading in version 6.0.0