### PR TITLE
fix: desktop can be restart when it was killed

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
+++ b/systemd/dde-session-initialized.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
@@ -20,5 +20,5 @@ Type=simple
 ExecStart=/usr/bin/dde-shell -p %I
 TimeoutStartSec=infinity
 Slice=session.slice
-Restart=on-failure
+Restart=always
 RestartSec=1s


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-313563

## Summary by Sourcery

Bug Fixes:
- Ensure the desktop shell plugin service can be restarted after being terminated unexpectedly