### PR TITLE
fix: don't target dde-session-shutdown when kwin failure

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.99.16) unstable; urgency=medium
+
+  * fix: don't target dde-session-shutdown when kwin failure
+
+ -- luhongxu <luhongxu@deepin.org>  Thu, 15 May 2025 11:35:19 +0800
+
 dde-session (1.99.15) unstable; urgency=medium
 
   * fix: desktop can be restart when it was killed

--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -1,8 +1,5 @@
 [Unit]
 Description=dde on X11
-# On X11, try to show the dde Session Failed screen
-OnFailure=dde-session-shutdown.target
-OnFailureJobMode=replace
 CollectMode=inactive-or-failed
 
 Requisite=dde-session-pre.target


### PR DESCRIPTION
log: when kwin failure, we should try to restart kwin, shouldn't showdown dde session

## Summary by Sourcery

Prevent dde session shutdown on KWin failure by removing the shutdown target and enabling automatic restart

Bug Fixes:
- Do not trigger dde-session-shutdown.target when KWin fails

Enhancements:
- Use systemd Restart directive to restart KWin on failure