### PR TITLE
fix: unset systemd-user's DISPLAY env when system logs out

### DIFF
--- a/systemd/dde-session-manager.service.in
+++ b/systemd/dde-session-manager.service.in
@@ -19,4 +19,5 @@ NotifyAccess=main
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-session --systemd-service
 ExecStopPost=@CMAKE_INSTALL_FULL_LIBEXECDIR@/dde-session-ctl --shutdown
 ExecStopPost=-/bin/sh -c 'test "$SERVICE_RESULT" != "exec-condition" && systemctl --user unset-environment XDG_CURRENT_DESKTOP'
+ExecStopPost=-/bin/sh -c 'test "$SERVICE_RESULT" != "exec-condition" && systemctl --user unset-environment DISPLAY'
 Slice=session.slice


### PR DESCRIPTION
The DISPLAY environment variable should be reset
when logging out of the system to avoid the dde-session using the wrong DISPLAY environment variable
in a multi-user login situation.

Log: as title
Pms: BUG-314781

## Summary by Sourcery

Bug Fixes:
- Unset the X11 DISPLAY variable in the systemd user service upon logout to avoid wrong DISPLAY inheritance in multi-user scenarios