### PR TITLE
chore: bump version to 1.99.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.99.17) unstable; urgency=medium
+
+  * fix: unset systemd-user's DISPLAY env when system logs out
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 15 May 2025 21:06:38 +0800
+
 dde-session (1.99.16) unstable; urgency=medium
 
   * fix: don't target dde-session-shutdown when kwin failure


### PR DESCRIPTION
update changelog to 1.99.17

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 1.99.17