### PR TITLE
fix: 解决音效服务异常的问题

### DIFF
--- a/src/dde-session/impl/sessionmanager.h
+++ b/src/dde-session/impl/sessionmanager.h
@@ -112,6 +112,8 @@ private:
     void emitStageChanged(int);
     void emitCurrentSessionPathChanged(QDBusObjectPath);
     void emitCurrentUidChanged(QString);
+    void playSoundAutoLogin(const QString& event);
+    void playSoundLogout(const QString& event);
 
     void playSound(const QString &event);
 


### PR DESCRIPTION
登录时如果使用alsa播放音效，会导致pa获取pipewire初始化失败，alsa抢占着通道。dde也会初始化audio模块失败。

Log: 解决音效服务异常的问题
pms: BUG-317093

## Summary by Sourcery

Use dedicated D-Bus interfaces for login and logout sound playback to avoid ALSA and PulseAudio/PipeWire channel contention, fixing audio service initialization failures.

Bug Fixes:
- Prevent login sound playback from blocking PipeWire initialization by avoiding ALSA and using a session-bus D-Bus interface
- Ensure logout sound uses ALSA directly over PulseAudio/PipeWire to avoid audio module startup failures

Enhancements:
- Introduce playSoundAutoLogin and playSoundLogout methods in SessionManager for context-appropriate sound playback
- Replace generic playSound calls for login and logout events with the new specialized methods