### PR TITLE
chore: bump version to 1.99.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (1.99.19) unstable; urgency=medium
+
+  * chore: add dde quick login
+
+ -- zhaoyingzhen <zhaoyingzhen@uniontech.com>  Fri, 06 Jun 2025 09:37:10 +0800
+
 dde-session (1.99.18) unstable; urgency=medium
 
   * fix: 解决音效服务异常的问题


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update debian/changelog with new version 1.99.19