### PR TITLE
fix: start deepin-keyring-whitebox when dde-session starting

### DIFF
--- a/src/dde-session/main.cpp
+++ b/src/dde-session/main.cpp
@@ -111,7 +111,11 @@ int main(int argc, char *argv[])
         return app.exec();
     }
 
-    // systemd-service
+    /* ---systemd-service--- */
+
+    // QProcess no block "/usr/bin/deepin-keyring-whitebox", "--opt-client=waitfifonotify"),BUG-255907
+    QProcess::startDetached("/usr/bin/deepin-keyring-whitebox", QStringList() << "--opt-client=waitfifonotify");
+
     auto* session = new Session;
     new Session1Adaptor(session);
     QDBusConnection::sessionBus().registerService("org.deepin.dde.Session1");


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-319375

## Summary by Sourcery

Bug Fixes:
- Launch /usr/bin/deepin-keyring-whitebox with --opt-client=waitfifonotify in dde-session's main to avoid blocking on startup