### PR TITLE
chore: bump version to 1.99.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session (1.99.20) unstable; urgency=medium
+
+  * fix: start deepin-keyring-whitebox when dde-session starting
+  * fix: using DPMS to close screen when need hibernate
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 19 Jun 2025 09:52:01 +0800
+
 dde-session (1.99.19) unstable; urgency=medium
 
   * chore: add dde quick login


### PR DESCRIPTION
update changelog to 1.99.20

## Summary by Sourcery

Chores:
- Update debian/changelog to version 1.99.20