### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (2.0.0) unstable; urgency=medium
+
+  * feat: update session configuration for Deepin Desktop Environment
+
+ -- fuleyi <fuleyi@uniontech.com>  Fri, 20 Jun 2025 16:59:39 +0800
+
 dde-session (1.99.21) unstable; urgency=medium
 
   * feat: enable position independent code in CMake


### PR DESCRIPTION
update changelog to 2.0.0

## Summary by Sourcery

Chores:
- Bump Debian package version to 2.0.0 in debian/changelog