### PR TITLE
fix: launch dde-lock.service when lock was unlocked in quick login mode

### DIFF
--- a/systemd/dde-session-pre.target.wants/dde-quick-login@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-quick-login@x11.service
@@ -12,6 +12,9 @@ Before=dde-session-pre.target
 Wants=org.dde.session.Daemon1.service
 After=org.dde.session.Daemon1.service
 
+# SuccessExitStatus=0,launch dde-lock.service
+OnSuccess=dde-lock.service
+
 [Service]
 Slice=session.slice
 Type=notify
@@ -19,6 +22,7 @@ Type=notify
 ExecCondition=/bin/sh -c '[ "$DDE_QUICKLOGIN" = "true" ] || exit 2'
 ExecCondition=/bin/sh -c '[ "$XDG_SESSION_TYPE" = "%I" ] || exit 3'
 ExecStart=/usr/bin/dde-quick-login
+SuccessExitStatus=0
 Restart=on-failure
 RestartSec=300ms
 StartLimitBurst=3


### PR DESCRIPTION
need luanch dde-lock,becase dde-lock need listen sessionActived.

Log: as title
Pms: BUG-321333

## Summary by Sourcery

Bug Fixes:
- Start dde-lock.service when unlocking in quick login mode to ensure sessionActive events are handled correctly.