### PR TITLE
fix: update systemd service configurations

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-shell@DDE.service
+++ b/systemd/dde-session-initialized.target.wants/dde-shell@DDE.service
@@ -32,5 +32,5 @@ Type=simple
 ExecStart=/usr/bin/dde-shell -C %I --serviceName=org.deepin.dde.shell -d org.deepin.ds.desktop
 TimeoutStartSec=infinity
 Slice=session.slice
-Restart=on-failure
+Restart=always
 RestartSec=1s


### PR DESCRIPTION
1. Changed restart policy from 'on-failure' to 'always' for dde-
shell@DDE.service to ensure continuous operation
2. These changes improve service reliability and simplify configuration
by removing redundant limits

fix: 更新 systemd 服务配置

1. 将 dde-shell@DDE.service 的重启策略从 'on-failure' 改为 'always' 以确
保持续运行
2. 这些改动通过移除冗余限制提高了服务可靠性并简化了配置

pms:BUG-321773

## Summary by Sourcery

Simplify and improve reliability of dde-shell systemd services by removing redundant restart limits and enabling continuous restarts for the main service

Enhancements:
- Remove StartLimitBurst=3 from dde-shell and dde-shell-plugin services
- Change Restart policy of dde-shell@DDE.service from 'on-failure' to 'always'