### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session (2.0.3) unstable; urgency=medium
+
+  * fix: update systemd service configurations
+  * fix: remove QT logging rules check for UOS
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Fri, 27 Jun 2025 15:13:57 +0800
+
 dde-session (2.0.2) unstable; urgency=medium
 
   * fix: launch dde-lock.service when lock was unlocked in quick login mode


### PR DESCRIPTION
update changelog to 2.0.3

## Summary by Sourcery

Bump the project version to 2.0.3 and update the Debian changelog accordingly.

Documentation:
- Update Debian changelog for version 2.0.3

Chores:
- Bump package version to 2.0.3