### PR TITLE
fix: update build hardening flags and cmake configuration

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,5 +2,10 @@
 
 include /usr/share/dpkg/default.mk
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
+
 %:
 	dh $@ --buildsystem=cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Tools)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set (CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "-W -Wall -fPIC -fstack-protector-all -z relro -z noexecstack -z now -pie")
 
 # qdbusxml2cpp-fix
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/dbusinterface/)


### PR DESCRIPTION
1. Removed redundant compiler flags from CMakeLists.txt that are now handled by debian/rules
2. Added security hardening build options in debian/rules including:
   - Enabling all hardening features
   - Adding -Wall warning flags for C/C++
   - Setting secure linker flags (RELRO, NOW, noexecstack)
3. Cleaned up CMake configuration by removing duplicate flags that are now handled at Debian build level

fix: 更新构建加固标志和cmake配置

1. 从CMakeLists.txt中移除了现在由debian/rules处理的冗余编译器标志
2. 在debian/rules中添加了安全加固构建选项包括：
   - 启用所有加固功能
   - 为C/C++添加-Wall警告标志
   - 设置安全链接器标志(RELRO, NOW, noexecstack)
3. 通过移除现在由Debian构建层处理的重复标志来清理CMake配置

## Summary by Sourcery

Consolidate security and warning flags into debian/rules for build hardening and clean up redundant CMake settings

Enhancements:
- Enable comprehensive security hardening and warning flags in the Debian build configuration

Build:
- Remove redundant compiler flags from CMakeLists.txt now managed by debian/rules
- Add secure linker flags (RELRO, NOW, noexecstack) and -Wall warnings to debian/rules