### PR TITLE
chore: bump version to 2.0.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (2.0.4) unstable; urgency=medium
+
+  * fix: update build hardening flags and cmake configuration
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:52:38 +0800
+
 dde-session (2.0.3) unstable; urgency=medium
 
   * fix: update systemd service configurations


### PR DESCRIPTION
update changelog to 2.0.4

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 2.0.4