### PR TITLE
fix: avoid memory leak

### DIFF
--- a/src/utils/fifo.cpp
+++ b/src/utils/fifo.cpp
@@ -13,8 +13,9 @@
 #include <errno.h>
 #include <QDebug>
 
-Fifo::Fifo()
-    : m_fd(-1)
+Fifo::Fifo(QObject *parent)
+    : QObject(parent)
+    , m_fd(-1)
 {
     m_fifoPath = QString(getenv("HOME")) + "/.cache/dde-session-fifo";
 }

--- a/src/utils/fifo.h
+++ b/src/utils/fifo.h
@@ -10,9 +10,10 @@
 
 class Fifo : public QObject
 {
+    Q_OBJECT
 public:
-    Fifo();
-    ~Fifo();
+    Fifo(QObject *parent = nullptr);
+    virtual ~Fifo();
 
     int Read(QString &data);
     int Write(QString data);


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-318023

## Summary by Sourcery

Ensure proper Qt object ownership and cleanup to eliminate memory leaks in dde-session by parenting dynamically allocated objects and disposing of FIFO instances after use.

Bug Fixes:
- Prevent memory leaks by assigning QApplication as parent to QDBusServiceWatcher, Session, WMSwitcher, and Fifo objects and deleting FIFO instances after use.

Enhancements:
- Convert Fifo to a QObject subclass with parent support and integrate deleteLater on read completion.
- Simplify FIFO write logic by executing it synchronously instead of spawning a separate thread.
- Parent all dynamically allocated Qt objects to the application to leverage Qt’s automatic memory management.