### PR TITLE
fix: resolve keyring prompt issue during login by moving keyring star…

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -3,6 +3,7 @@ configure_file(xsessions/deepin.desktop.in xsessions/deepin.desktop)
 set(XSESSION
     ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/00deepin-dde-env
     ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/01deepin-profile
+    ${CMAKE_CURRENT_SOURCE_DIR}/Xsession.d/97deepin-keyring-wb
 )
 
 set(PROFILE

--- a/misc/Xsession.d/97deepin-keyring-wb
+++ b/misc/Xsession.d/97deepin-keyring-wb
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Start deepin-keyring-whitebox and gnome-keyring-daemon for DDE session
+
+if [ -x /usr/bin/deepin-keyring-whitebox ]; then
+    echo "start deepin-keyring-whitebox client"
+    /usr/bin/deepin-keyring-whitebox --opt-client=waitfifonotify || true
+fi
+
+if [ -x /usr/bin/gnome-keyring-daemon ]; then
+    echo "start gnome-keyring-daemon with components secrets,pkcs11,ssh"
+    /usr/bin/gnome-keyring-daemon --start --components=secrets,pkcs11,ssh || true
+fi 

--- a/src/dde-session/environmentsmanager.cpp
+++ b/src/dde-session/environmentsmanager.cpp
@@ -14,7 +14,6 @@
 EnvironmentsManager::EnvironmentsManager()
 {
     createGeneralEnvironments();
-    createKeyringEnvironments();
     createDBusEnvironments();
 }
 
@@ -105,23 +104,6 @@ void EnvironmentsManager::createGeneralEnvironments()
         m_envMap.insert("XCURSOR_SIZE", "24");
     }
 
-}
-
-void EnvironmentsManager::createKeyringEnvironments()
-{
-    // man gnome-keyring-daemon:
-    // The daemon will print out various environment variables which should be set
-    // in the user's environment, in order to interact with the daemon.
-    EXEC_COMMAND("/usr/bin/gnome-keyring-daemon", QStringList() << "--start" << "--components=secrets,pkcs11,ssh");
-    const QByteArray &output = p.readAllStandardOutput();
-    QByteArrayList envList = output.split('\n');
-    for (auto env : envList) {
-        auto list = env.split('=');
-        if (list.size() != 2)
-            continue;
-
-        m_envMap.insert(list.at(0), list.at(1));
-    }
 }
 
 void EnvironmentsManager::createDBusEnvironments()

--- a/src/dde-session/environmentsmanager.h
+++ b/src/dde-session/environmentsmanager.h
@@ -19,7 +19,6 @@ public:
 
 private:
     void createGeneralEnvironments();
-    void createKeyringEnvironments();
     void createDBusEnvironments();
 
     bool unsetEnv(QString env);

--- a/src/dde-session/main.cpp
+++ b/src/dde-session/main.cpp
@@ -113,9 +113,6 @@ int main(int argc, char *argv[])
 
     /* ---systemd-service--- */
 
-    // QProcess no block "/usr/bin/deepin-keyring-whitebox", "--opt-client=waitfifonotify"),BUG-255907
-    QProcess::startDetached("/usr/bin/deepin-keyring-whitebox", QStringList() << "--opt-client=waitfifonotify");
-
     auto* session = new Session(&app);
     new Session1Adaptor(session);
     QDBusConnection::sessionBus().registerService("org.deepin.dde.Session1");


### PR DESCRIPTION
…tup to Xsession.d

Previously, dde-update could block the startup of dde-session during update checks, causing deepin-keyring-whitebox to timeout while waiting for the client to unlock the keyring. This commit moves the startup of deepin-keyring-whitebox and gnome-keyring-daemon to an Xsession.d script, ensuring the keyring is initialized independently and preventing login keyring prompt timeouts.

log:
pms: BUG-323511

## Summary by Sourcery

Move keyring initialization out of dde-session code into an Xsession.d script to prevent login hangs and timeouts

Bug Fixes:
- Fix login keyring prompt hanging due to dde-update blocking dde-session startup

Enhancements:
- Shift deepin-keyring-whitebox and gnome-keyring-daemon startup to a new Xsession.d script
- Remove inline keyring daemon initialization from EnvironmentsManager and main

Build:
- Include the new 97deepin-keyring-wb script in CMakeLists for Xsession.d installation