### PR TITLE
fix: resolve audio service stop issue during logout

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -636,15 +636,9 @@ void SessionManager::stopPulseAudioService()
     auto msg = interface.call("NoRestartPulseAudio");
     if (!msg.errorMessage().isEmpty())
         qWarning() << "error: " << msg.errorMessage();
-
-    const QString audioServer = getAudioServerBackend();
-
-    STOP_SERVICE(audioServer);
-    // pipewire also need to stop pipwire-pulse socket
-    if (audioServer == PIPEWIRE_SOCKET) {
-        STOP_SERVICE(PIPEWIRE_PULSE_SOCKET);
-    }
-    VIEW_SERVICE(audioServer);
+    msg = interface.call("StopAudioService");
+    if (!msg.errorMessage().isEmpty())
+        qWarning() << "error: " << msg.errorMessage();
 }
 
 void SessionManager::stopBAMFDaemon()


### PR DESCRIPTION
Previously, stopping audio service was handled asynchronously through direct service commands, which didn't guarantee immediate termination. This caused ALSA to remain occupied when playing logout sound effects, leading to playback failures. The fix replaces this with a synchronous call to the backend's StopAudioService method to ensure proper audio service termination before logout sound playback.

Log: Fixed issue where logout sound effects failed to play due to audio service still running

Influence:
1. Test logout sound effects playback during system logout
2. Verify audio service properly terminates before sound playback
3. Check system stability during logout sequence
4. Test with different audio backends (ALSA, PipeWire)

fix: 解决注销时音频服务停止问题

之前通过直接服务命令异步停止音频服务，无法保证立即终止。这导致播
放注销音效时ALSA仍处于占用状态，造成播放失败。现改为同步调用后端的
StopAudioService方法，确保在播放注销音效前正确终止音频服务。

Log: 修复了由于音频服务仍在运行导致注销音效播放失败的问题
PMS: BUG-315787
Influence:
1. 测试系统注销时的注销音效播放
2. 验证音频服务在声音播放前正确终止
3. 检查注销序列中的系统稳定性
4. 使用不同音频后端(ALSA, PipeWire)进行测试