### PR TITLE
chore: update changelog to 2.0.21

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (2.0.21) unstable; urgency=medium
+
+  * fix: support showing lock screen triggered by logind lock signal
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 18 Mar 2026 14:15:34 +0800
+
 dde-session (2.0.20) unstable; urgency=medium
 
   * fix: prevent whitebox keyring from blocking xrdp remote login


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.21

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.21
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog metadata to reflect version 2.0.21 targeting master.