### PR TITLE
perf: optimize systemd services startup and cleanup dependencies

### DIFF
--- a/systemd/dde-session-core.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
+++ b/systemd/dde-session-core.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
@@ -15,7 +15,8 @@ Requires=dbus.socket
 After=dbus.socket
 
 [Service]
-Type=simple
+Type=dbus
+BusName=com.deepin.dde.desktop
 ExecStart=/usr/bin/dde-shell -p %I
 TimeoutStartSec=infinity
 Slice=session.slice

--- a/systemd/dde-session-core.target.wants/dde-shell@DDE.service
+++ b/systemd/dde-session-core.target.wants/dde-shell@DDE.service
@@ -14,20 +14,12 @@ Before=dde-session-core.target
 Requires=dbus.socket
 After=dbus.socket
 
-#FIXME: maybe AM is invalid
-# old AM
-Wants=org.deepin.dde.Application1.Manager.service
-After=org.deepin.dde.Application1.Manager.service
-# new AM
+# AM
 Wants=org.desktopspec.ApplicationManager1.service
-After=org.desktopspec.ApplicationManager1.service
-
-# No longer needed. Just a dependency of some of dde-shell's plugins.
-# Wants=org.dde.session.Daemon1.service
-# After=org.dde.session.Daemon1.service
 
 [Service]
-Type=simple
+Type=dbus
+BusName=org.deepin.dde.Dock1
 ExecStart=/usr/bin/dde-shell -C %I --serviceName=org.deepin.dde.shell -d org.deepin.ds.desktop
 TimeoutStartSec=infinity
 Slice=session.slice

--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=dde on X11
 CollectMode=inactive-or-failed
+# Only start if the template instance matches the session type (systemd >= 246)
+ConditionEnvironment=XDG_SESSION_TYPE=%I
 
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
@@ -12,13 +14,7 @@ StartLimitBurst=3
 [Service]
 Slice=session.slice
 Type=notify
-# NOTE: This can be replaced with ConditionEnvironment=XDG_SESSION_TYPE=%I in
-#       the [Unit] section with systemd >= 246. Also, the current solution is
-#       kind of painful as systemd had a bug where it retries the condition.
-# Only start if the template instance matches the session type.
-ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" = "%I" || exit 2'
-ExecStartPre=-/bin/sh -c 'cp -n /etc/xdg/kglobalshortcutsrc $HOME/.config/kglobalshortcutsrc'
-ExecStartPre=-/bin/sh -c 'sed -i "s/deepin-kwin/kwin/g" $HOME/.config/kglobalshortcutsrc'
+ExecStartPre=-/bin/sh -c 'cp -n /etc/xdg/kglobalshortcutsrc "$HOME/.config/kglobalshortcutsrc"; sed -i "s/deepin-kwin/kwin/g" "$HOME/.config/kglobalshortcutsrc"'
 ExecStart=/usr/bin/kwin_x11 --replace
 # Exit code 1 means we are probably *not* dealing with an extension failure
 SuccessExitStatus=1


### PR DESCRIPTION
- Change dde-shell and dde-shell-plugin services to Type=dbus and specify BusName to ensure correct startup order.
- Remove obsolete application manager dependencies and comments in dde-shell service.
- Use ConditionEnvironment in dde-session@x11 service and consolidate ExecStartPre for better performance.

- 将 dde-shell 和 dde-shell-plugin 服务类型改为 Type=dbus 并指定 BusName，确保正确的启动顺序。
- 移除 dde-shell 服务中过时的应用管理器依赖及注释。
- 在 dde-session@x11 服务中改用 ConditionEnvironment 并合并 ExecStartPre 以提升性能。

Log: optimize systemd services startup and cleanup dependencies
Change-Id: I75754a0dd09172d891237955456d881a86cee34b

## Summary by Sourcery

Optimize systemd service startup ordering and cleanup obsolete dependencies for dde-shell, dde-shell-plugin, and dde-session@x11.

Enhancements:
- Switch dde-shell and dde-shell-plugin services to D-Bus-activated units with explicit bus names to improve startup ordering.
- Refine dde-session@x11 service conditions and pre-start commands to streamline session startup performance.

Chores:
- Remove outdated dde-shell application manager dependencies and related comments from systemd unit configuration.