### PR TITLE
chore: update changelog to 2.0.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session (2.0.23) unstable; urgency=medium
+
+  * perf: optimize systemd services startup and cleanup dependencies
+  * feat: add dde session boot time and memory analysis tool
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 24 Apr 2026 09:58:22 +0800
+
 dde-session (2.0.22) unstable; urgency=medium
 
   * fix: add X connection monitoring for session logout


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.23

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.23
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.23 targeting the master branch.