### PR TITLE
feat: log detailed dbus error messages on failure

### DIFF
--- a/src/dde-session/environmentsmanager.cpp
+++ b/src/dde-session/environmentsmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,7 +51,7 @@ void EnvironmentsManager::init()
         QDBusPendingReply<void> replySystemd1 = systemd1.SetEnvironment(envs);
         replySystemd1.waitForFinished();
         if (replySystemd1.isError()) {
-            qWarning() << "failed to set systemd1 envs: " << envs;
+            qWarning() << "failed to set systemd1 envs: " << envs << ", error:" << replySystemd1.error();
         }
 
         // dbus
@@ -64,7 +64,7 @@ void EnvironmentsManager::init()
         QDBusPendingReply<void> replyDbus = dbus.UpdateActivationEnvironment(envInfos);
         replyDbus.waitForFinished();
         if (replyDbus.isError()) {
-            qWarning() << "failed to update dbus envs:" << envInfos;
+            qWarning() << "failed to update dbus envs:" << envInfos << ", error:" << replyDbus.error();
         }
     }
 
@@ -146,7 +146,7 @@ bool EnvironmentsManager::unsetEnv(QString env)
     QDBusPendingReply<void> replyDbus = dbus.UpdateActivationEnvironment(envs);
     replyDbus.waitForFinished();
     if (replyDbus.isError()) {
-        qWarning() << "unset dbus env failed:" << env;
+        qWarning() << "unset dbus env failed:" << env << ", error:" << replyDbus.error();
         return false;
     }
 

--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -990,14 +990,14 @@ void SessionManager::handleLoginSessionUnlocked()
             org::freedesktop::DBus dbusInter("org.freedesktop.DBus", "/org/freedesktop/DBus", QDBusConnection::sessionBus());
             QDBusPendingReply<QString> ownerReply = dbusInter.GetNameOwner("org.deepin.dde.LockFront1");
             if (ownerReply.isError()) {
-                qWarning() << "failed to get lockFront service owner";
+                qWarning() << "failed to get lockFront service owner" << ", error:" << ownerReply.error();
                 return;
             }
             const QString &owner = ownerReply.value();
 
             QDBusPendingReply<uint> pidReply = dbusInter.GetConnectionUnixProcessID(owner);
             if (pidReply.isError()) {
-                qWarning() << "failed to get lockFront service pid";
+                qWarning() << "failed to get lockFront service pid" << ", error:" << pidReply.error();
                 return;
             }
             uint pid = pidReply.value();

--- a/src/dde-session/main.cpp
+++ b/src/dde-session/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,7 +36,7 @@ int startSystemdUnit(org::freedesktop::systemd1::Manager &systemd1, const QStrin
     QDBusPendingReply<QDBusObjectPath> reply = systemd1.StartUnit(unitName, unitType);
     reply.waitForFinished();
     if (reply.isError()) {
-        qWarning() << "start systemd unit failed:" << unitName;
+        qWarning() << "start systemd unit failed:" << unitName << ", error:" << reply.error();
         return -1;
     }
     qInfo() << "success to start systemd unit:" << unitName << ", job path:" << reply.value().path();


### PR DESCRIPTION
The current implementation only printed generic warning messages when D-Bus calls failed during session initialization. This made it difficult to diagnose underlying issues like systemd transaction conflicts or permission errors.

Log: Added detailed D-Bus error reporting to improve diagnostic capability

Influence:
1. Verify that logs now show detailed error strings when D-Bus calls fail

## Summary by Sourcery

Improve diagnostic logging for failed D-Bus and systemd operations during session management.

Enhancements:
- Augment warning logs for systemd environment updates, D-Bus activation environment updates, and lock screen D-Bus queries with detailed error information.
- Include detailed error output when starting systemd units fails to aid in troubleshooting startup issues.