### PR TITLE
chore: update changelog to 2.0.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (2.0.24) unstable; urgency=medium
+
+  * perf: optimize startup time by reading scale factor from config
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:21 +0800
+
 dde-session (2.0.23) unstable; urgency=medium
 
   * perf: optimize systemd services startup and cleanup dependencies


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.24

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.24
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.24 targeting master.