### PR TITLE
[暂不合并]feat(systemd): add THP disable pre-start for DDE services

### DIFF
--- a/systemd/dde-session-core.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
+++ b/systemd/dde-session-core.target.wants/dde-shell-plugin@org.deepin.ds.desktop.service
@@ -18,6 +18,7 @@ After=dbus.socket
 Type=dbus
 BusName=com.deepin.dde.desktop
 ExecStart=/usr/bin/dde-shell -p %I
+ExecStartPre=-/usr/libexec/dde-thp-disable
 TimeoutStartSec=infinity
 Slice=session.slice
 Restart=always

--- a/systemd/dde-session-core.target.wants/dde-shell@DDE.service
+++ b/systemd/dde-session-core.target.wants/dde-shell@DDE.service
@@ -21,6 +21,7 @@ Wants=org.desktopspec.ApplicationManager1.service
 Type=dbus
 BusName=org.deepin.dde.Dock1
 ExecStart=/usr/bin/dde-shell -C %I --serviceName=org.deepin.dde.shell -d org.deepin.ds.desktop
+ExecStartPre=-/usr/libexec/dde-thp-disable
 TimeoutStartSec=infinity
 Slice=session.slice
 Restart=always

--- a/systemd/dde-session-initialized.target.wants/dde-lock.service
+++ b/systemd/dde-session-initialized.target.wants/dde-lock.service
@@ -18,6 +18,7 @@ After=org.dde.session.Daemon1.service
 Type=simple
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" != "wayland" || exit 2'
 ExecStart=/usr/bin/dde-lock
+ExecStartPre=-/usr/libexec/dde-thp-disable
 TimeoutStartSec=infinity
 Slice=session.slice
 Restart=on-failure

--- a/systemd/dde-session-initialized.target.wants/dde-polkit-agent.service
+++ b/systemd/dde-session-initialized.target.wants/dde-polkit-agent.service
@@ -14,6 +14,7 @@ Before=dde-session-initialized.target
 [Service]
 Type=simple
 ExecStart=/usr/lib/polkit-1-dde/dde-polkit-agent
+ExecStartPre=-/usr/libexec/dde-thp-disable
 TimeoutStartSec=infinity
 Slice=session.slice
 Restart=on-failure

--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -14,6 +14,7 @@ StartLimitBurst=3
 [Service]
 Slice=session.slice
 Type=notify
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStartPre=-/bin/sh -c 'cp -n /etc/xdg/kglobalshortcutsrc "$HOME/.config/kglobalshortcutsrc"; sed -i "s/deepin-kwin/kwin/g" "$HOME/.config/kglobalshortcutsrc"'
 ExecStart=/usr/bin/kwin_x11 --replace
 # Exit code 1 means we are probably *not* dealing with an extension failure


### PR DESCRIPTION
1. Added ExecStartPre directive to disable Transparent Huge Pages (THP) before DDE core services start
2. Applied to 5 services: dde-shell desktop plugin, dde-shell DDE, dde-lock, dde-polkit-agent, and dde-session@x11
3. Uses `-` prefix on dde-thp-disable to gracefully handle cases where the binary is absent

Log: Disable THP before DDE session services start to reduce memory overhead

feat(systemd): 为 DDE 服务添加 THP 禁用预启动步骤

1. 在 DDE 核心服务启动前添加 ExecStartPre 指令，用于禁用透明大页（THP）
2. 覆盖 5 个服务：dde-shell 桌面插件、dde-shell DDE、dde-lock、dde-polkit-agent、dde-session@x11
3. 对 dde-thp-disable 使用 `-` 前缀，避免二进制文件缺失时启动失败

Log: 在 DDE 会话服务启动前禁用 THP 以减少内存开销
PMS: TASK-390043