### PR TITLE
chore: update changelog to 2.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-session (2.0.25) unstable; urgency=medium
+
+  * fix(dde-session): fix thread safety in FIFO pipe handler
+  * refactor(dde-session): remove Dconf utility and dead code
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 20:07:58 +0800
+
 dde-session (2.0.24) unstable; urgency=medium
 
   * perf: optimize startup time by reading scale factor from config


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.25

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.25
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entries to reflect version 2.0.25 targeting master.