### PR TITLE
fix: change dde-lock service type from simple to forking

### DIFF
--- a/systemd/dde-session-initialized.target.wants/dde-lock.service
+++ b/systemd/dde-session-initialized.target.wants/dde-lock.service
@@ -15,7 +15,8 @@ Wants=org.dde.session.Daemon1.service
 After=org.dde.session.Daemon1.service
 
 [Service]
-Type=simple
+Type=forking
+GuessMainPID=yes
 ExecCondition=/bin/sh -c 'test "$XDG_SESSION_TYPE" != "wayland" || exit 2'
 ExecStart=/usr/bin/dde-lock
 TimeoutStartSec=infinity


### PR DESCRIPTION
Change the systemd service type for dde-lock from "simple" to "forking" to ensure
proper startup when using the deepin-security-loader mechanism. The simple type
caused startup failures, while forking allows the daemon process to properly
signal readiness to systemd. Added GuessMainPID=yes to help systemd identify
the main process when the daemon forks.

Log: Fixed dde-lock startup issue by changing service type to forking

Influence:
1. Verify dde-lock starts successfully on system boot
2. Test dde-lock functionality after system resume from sleep
3. Verify dde-lock works correctly on both X11 and Wayland sessions
4. Test lock screen activation and deactivation
5. Verify no service timeout or startup failures in systemd journal
6. Test with other lock screen related operations (switch user, etc.)

fix: 将 dde-lock 服务类型从 simple 改为 forking

将 dde-lock 的 systemd 服务类型从 "simple" 改为 "forking"，以确保在使用 deepin-security-loader 机制时能够正常启动。原先的 simple 类型会导致启动 失败，
而 forking 类型允许守护进程正确地向 systemd 发送就绪信号。添加了
GuessMainPID=yes 以帮助 systemd 在守护进程 fork 时识别主进程。

Log: 修复 dde-lock 启动问题，将服务类型改为 forking

Influence:
1. 验证 dde-lock 在系统启动时能正常启动
2. 测试系统从休眠恢复后 dde-lock 的功能
3. 验证 dde-lock 在 X11 和 Wayland 会话下都能正常工作
4. 测试锁屏的激活和解锁操作
5. 验证 systemd 日志中没有服务超时或启动失败记录
6. 测试与其他锁屏相关操作的兼容性（切换用户等）

PMS: TASK-390841
Change-Id: I8f8ad77a4b39d5d7eaa02fe1271d72d6aab4597d