### PR TITLE
fix: route screen lock through logind on Wayland

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -426,6 +426,16 @@ void SessionManager::RequestHibernate()
 
 void SessionManager::RequestLock()
 {
+    if (Utils::IS_WAYLAND_DISPLAY) {
+        // On Wayland the lock screen is owned by treeland and driven via logind.
+        // The X11-only LockFront1 (dde-lock) has no provider here, so calling it
+        // would hang on a 120s D-Bus activation timeout. Ask logind to lock.
+        qDebug() << "RequestLock on wayland: ask logind to lock";
+        m_login1SessionInter->Lock();
+        m_inCallRequestLock = false;
+        return;
+    }
+
     QDBusInterface inter("org.deepin.dde.LockFront1", "/org/deepin/dde/LockFront1", "org.deepin.dde.LockFront1", QDBusConnection::sessionBus());
     
     // 使用异步调用方式防止当前线程阻塞
@@ -1025,6 +1035,15 @@ void SessionManager::handleLoginSessionLocked()
         return;
     }
 
+    if (Utils::IS_WAYLAND_DISPLAY) {
+        // On Wayland treeland shows the lock screen on this same logind Lock
+        // signal; only sync local state here (calling RequestLock would loop).
+        qDebug() << "handleLoginSessionLocked on wayland: sync local state";
+        m_locked = true;
+        emitLockChanged(true);
+        return;
+    }
+
     // 防止短时间内多次同时调用 RequestLock
     if (m_inCallRequestLock) {
         qDebug() << "handleLoginSessionLocked inCall is true, return";
@@ -1040,6 +1059,15 @@ void SessionManager::handleLoginSessionLocked()
 void SessionManager::handleLoginSessionUnlocked()
 {
     qDebug() << "login session unlocked.";
+
+    if (Utils::IS_WAYLAND_DISPLAY) {
+        // On Wayland there is no X11 LockFront1 process to kill; only sync state.
+        qDebug() << "handleLoginSessionUnlocked on wayland: sync local state";
+        m_locked = false;
+        emitLockChanged(false);
+        Q_EMIT Unlock();
+        return;
+    }
 
     bool sessionActive = m_login1SessionInter->active();
     if (sessionActive) {


### PR DESCRIPTION
## Summary
- On Wayland the lock screen is provided by **treeland** (driven by the logind `Lock` signal), but `SessionManager::RequestLock()` unconditionally called the **X11-only** `org.deepin.dde.LockFront1` (dde-lock).
- Under Wayland `dde-lock.service` is `ExecCondition`-disabled, so `org.deepin.dde.LockFront1` has no provider — the call hangs on the **120 s D-Bus activation timeout** and logs `failed to lock`. A Wayland guard previously existed on this path and was dropped in an earlier refactor.
- Gate the lock path on `Utils::IS_WAYLAND_DISPLAY`:
  - `RequestLock()` → `m_login1SessionInter->Lock()` so treeland shows the lock screen.
  - `handleLoginSessionLocked()` only syncs local lock state (treeland reacts to the same logind signal; re-entering `RequestLock` would loop).
  - `handleLoginSessionUnlocked()` only syncs state, skipping the X11 `LockFront1`-kill path that early-returns and leaves `m_locked` stale.

## Evidence (before fix)
```
dde-session: failed to lock, async error: Did not receive a reply ...
dbus-daemon: Failed to activate service 'org.deepin.dde.LockFront1': timed out (service_start_timeout=120000ms)
```

## Test plan
- On a treeland/Wayland session, trigger a lock (lock shortcut / idle) and confirm the journal no longer shows the `LockFront1` 120 s activation timeout / `failed to lock`.
- On X11, confirm the lock screen still comes up via `dde-lock` (LockFront1) as before.