### PR TITLE
chore: update changelog to 2.0.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-session (2.0.26) unstable; urgency=medium
+
+  * fix: change dde-lock service type from simple to forking
+  * fix: route screen lock through logind on Wayland
+  * feat: recover power mode after sleep/shutdown/reboot
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:57:06 +0800
+
 dde-session (2.0.25) unstable; urgency=medium
 
   * fix(dde-session): fix thread safety in FIFO pipe handler


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.26

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.26
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release notes for Debian package version 2.0.26 in debian/changelog.