### PR TITLE
fix: check multiple paths for dde-lock caller in SetLocked

### DIFF
--- a/src/dde-session/impl/sessionmanager.cpp
+++ b/src/dde-session/impl/sessionmanager.cpp
@@ -496,8 +496,13 @@ void SessionManager::SetLocked(bool lock)
     QFile file(cmdLine);
 
     // NOTE: 如果以deepin-turbo进行加速启动，这里是不准确的，可能需要判断desktop文件的全路径，不过deepin-turbo后续应该会放弃支持
-    if (!file.open(QIODevice::ReadOnly) || !file.readAll().startsWith("/usr/bin/dde-lock")) {
-        qWarning() << "failed to get caller infomation or caller is illegal.";
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning() << "SetLocked: failed to read caller cmdline:" << cmdLine;
+        return;
+    }
+    const QString caller = QString::fromUtf8(file.readAll());
+    if (!caller.startsWith("/usr/bin/dde-lock") && !caller.startsWith("/usr/libexec/deepin/dde-lock")) {
+        qWarning() << "SetLocked: illegal caller:" << caller;
         return;
     }
 


### PR DESCRIPTION
Update the caller validation in SetLocked to support both /usr/bin/dde- lock and /usr/libexec/deepin/dde-lock paths, as the lock binary location may vary across different system configurations or distributions. Also improve error handling by separating the file read failure check from the caller verification, providing clearer warnings in each case.

Log: Extended SetLocked caller path validation to include alternative dde-lock location, improving compatibility

Influence:
1. Test locking/unlocking screen from various callers (dde-lock at /usr/ bin/dde-lock and /usr/libexec/deepin/dde-lock)
2. Verify that unauthorized callers are properly rejected with warning
3. Test with missing or unreadable cmdline file for proper error handling
4. Check system log for appropriate warning messages in each case

fix: SetLocked 中检查 dde-lock 调用者的多个路径

更新 SetLocked 中的调用者验证，支持 /usr/bin/dde-lock 和 /usr/libexec/ deepin/dde-lock 两个路径，因为锁屏二进制位置可能因系统配置或发行版而异。
同时改进错误处理，将文件读取失败检查与调用者验证分开，为每种情况提供更清
晰的警告信息。

Log: 扩展 SetLocked 调用者路径验证，包含备选的 dde-lock 位置，提高兼容性

Influence:
1. 从不同调用者（/usr/bin/dde-lock 和 /usr/libexec/deepin/dde-lock）测试 锁屏/解锁功能
2. 验证未授权调用者是否被正确拒绝并发出警告
3. 测试 cmdline 文件缺失或不可读时的错误处理
4. 检查系统日志中每种情况下的适当警告信息

PMS: BUG-366505 BUG-366367
Change-Id: I0398d751e6e5eb3ff83a0dbc36e7647793b5d797