### PR TITLE
chore: update changelog to 2.0.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-session (2.0.27) unstable; urgency=medium
+
+  * fix: check multiple paths for dde-lock caller in SetLocked
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:37:51 +0800
+
 dde-session (2.0.26) unstable; urgency=medium
 
   * fix: change dde-lock service type from simple to forking


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.27

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.27
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entry to document version 2.0.27.