### PR TITLE
fix(systemd): delay startup after XSettings1 service for xsettings

### DIFF
--- a/systemd/dde-session-pre.target.wants/dde-session@x11.service
+++ b/systemd/dde-session-pre.target.wants/dde-session@x11.service
@@ -7,6 +7,8 @@ ConditionEnvironment=XDG_SESSION_TYPE=%I
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
 
+After=org.deepin.dde.XSettings1.service
+
 # Limit startup frequency more than the default
 StartLimitIntervalSec=15s
 StartLimitBurst=3


### PR DESCRIPTION
Add After=org.deepin.dde.XSettings1.service to ensure the service starts after XSettings1 reads the latest xsettings values.

添加 After=org.deepin.dde.XSettings1.service，确保在 XSettings1 读取最新的 xsettings 数值后启动，以获取正确的配置值。

Log: 调整服务启动顺序，在 XSettings1 后启动
PMS: BUG-349621
Influence: 影响 dde-session 启动顺序

## Summary by Sourcery

Deployment:
- Ensure the dde-session@x11 systemd unit starts only after org.deepin.dde.XSettings1.service to pick up updated xsettings values.